### PR TITLE
Give original author credits and set more generic description

### DIFF
--- a/dolla.gemspec
+++ b/dolla.gemspec
@@ -6,11 +6,11 @@ require "dolla/version"
 Gem::Specification.new do |spec|
   spec.name          = "dolla"
   spec.version       = Dolla::VERSION
-  spec.authors       = ["David Sanchez", "Carlos Muniz"]
-  spec.email         = ["sanchez.dav90@gmail.com", "mumo.crls@gmail.com"]
+  spec.authors       = ["Enrique Vidal", "David Sanchez", "Carlos Muniz"]
+  spec.email         = ["enrique@cloverinteractive.com", "sanchez.dav90@gmail.com", "mumo.crls@gmail.com"]
 
-  spec.summary       = %q{Dolla module for Agora payments.}
-  spec.description   = %q{Dolla is a gem that provide all payments methods to Agora.}
+  spec.summary       = %q{Dolla module for payment gateways.}
+  spec.description   = %q{Dolla is a gem that provide payments methods for bank gateways.}
   spec.homepage      = "https://github.com/amco/dolla."
   spec.license       = "MIT"
 


### PR DESCRIPTION
Adding the original author name and email to the gem, also, add a more generic description as we will like to abstract Adkira specific methods and make the gem more generic for different gateways.