### PR TITLE
Install Generator file

### DIFF
--- a/lib/generators/dolla/install_generator.rb
+++ b/lib/generators/dolla/install_generator.rb
@@ -1,7 +1,8 @@
 module Dolla
   module Generators
     class InstallGenerator < Rails::Generators::Base
-      source_root File.expand_path("../templates", __FILE__)
+      desc "This generator creates an initializer file at config/initializers"
+      source_root File.expand_path("../../templates", __FILE__)
 
       def copy_initializer
         template "dolla_initializer.rb", "config/initializers/dolla.rb"


### PR DESCRIPTION
### Solves
The generator doesn't find `templates` folder

### Changes 
- `install_generator` was changed to a better structure
- `source_root` was fixed